### PR TITLE
Fix htmlspecialchars() null deprecation

### DIFF
--- a/mod_contentcart/mod_contentcart.php
+++ b/mod_contentcart/mod_contentcart.php
@@ -16,6 +16,6 @@ if ($params->def('prepare_content', 1))
 	$module->content = JHtml::_('content.prepare', $module->content, '', 'mod_contentcart.content');
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_contentcart', $params->get('layout', 'default'));


### PR DESCRIPTION
Передача `null` вместо строки в функцию [htmlspecialchars()](https://www.php.net/htmlspecialchars), начиная с PHP 8.1, [объявлена deprecated](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal).

Сейчас, с включённым выводом ошибок, перед модулем корзины выводится сообщение:

> Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated